### PR TITLE
[~] Fix Max recursion crash

### DIFF
--- a/1fichier-dl/core/download/helpers.py
+++ b/1fichier-dl/core/download/helpers.py
@@ -8,6 +8,9 @@ FIRST_RUN = True
 PROXY_TXT_API = 'https://www.proxyscan.io/api/proxy?type=https&format=txt&limit=20'
 PLATFORM = os.name
 
+class DownloadRecursionError(Exception):
+    pass
+
 def get_proxies(settings: str) -> list:
     '''
     Get proxies (str) from API.

--- a/1fichier-dl/core/download/workers.py
+++ b/1fichier-dl/core/download/workers.py
@@ -2,7 +2,7 @@ import os
 from .download import *
 from PyQt5.QtCore import Qt, QObject, QRunnable, pyqtSignal, pyqtSlot
 from PyQt5.QtGui import QStandardItem
-from .helpers import is_valid_link
+from .helpers import is_valid_link, DownloadRecursionError
 
 class WorkerSignals(QObject):
     download_signal = pyqtSignal(list, str, bool, str, int)
@@ -120,7 +120,11 @@ class DownloadWorker(QRunnable):
 
     @pyqtSlot()
     def run(self):
-        dl_name = download(self)
+        try:
+            dl_name = download(self)
+        except DownloadRecursionError:
+            self.signals.update_signal.emit(self.data, [None, None, 'Error, Please retry', '0 B/s'])
+            return
         self.dl_name = dl_name
 
         if dl_name and self.stopped:


### PR DESCRIPTION
#22 
Fix Maximum recursion depth exceeded while calling a Python object crash.
While looping on recursion to download/get proxies, use a counter which check if the loop is near the limit.
if near the limit will and raise an error to avoid crash, the error will signal the download as an error :)

Please check these posts : 
https://stackoverflow.com/questions/14222416/recursion-in-python-runtimeerror-maximum-recursion-depth-exceeded-while-callin
https://docs.python.org/2/library/sys.html#sys.getrecursionlimit